### PR TITLE
Added 'convertToTranslation' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "onCommand:lingua.gotoTranslation",
         "onCommand:lingua.selectLocaleFile",
         "onCommand:lingua.createTranslation",
-        "onCommand:lingua.changeTranslation"
+        "onCommand:lingua.changeTranslation",
+        "onCommand:lingua.convertToTranslation"
     ],
     "main": "./dist/extension.js",
     "contributes": {
@@ -35,11 +36,15 @@
             },
             {
                 "command": "lingua.createTranslation",
-                "title": "Lingua: Create Translation"
+                "title": "Lingua: Create translation"
             },
             {
                 "command": "lingua.changeTranslation",
-                "title": "Lingua: Change Translation"
+                "title": "Lingua: Change translation"
+            },
+            {
+                "command": "lingua.convertToTranslation",
+                "title": "Lingua: Convert text to translation"
             }
         ],
         "menus": {
@@ -59,6 +64,10 @@
                 },
                 {
                     "command": "lingua.changeTranslation",
+                    "group": "lingua"
+                },
+                {
+                    "command": "lingua.convertToTranslation",
                     "group": "lingua"
                 }
             ]

--- a/src/translation/translation-set.ts
+++ b/src/translation/translation-set.ts
@@ -1,5 +1,5 @@
 import { isArray } from 'util';
-import { Uri, workspace } from 'vscode';
+import { Uri } from 'vscode';
 
 export class TranslationSet {
     private _mainTranslationSet: { [path: string]: string } = {};
@@ -21,6 +21,10 @@ export class TranslationSet {
 
     public isPartialMatch(path: string): boolean {
         return this._secondaryTranslationSet.has(path);
+    }
+
+    public isEmpty(): boolean {
+        return !!!this.keys.length; // KEYS!!! HOW LONG ARE YOU?!
     }
 
     public get keys(): string[] {

--- a/src/translation/translation-sets.ts
+++ b/src/translation/translation-sets.ts
@@ -5,7 +5,7 @@ import { LinguaSettings } from '../lingua-settings';
 export class TranslationSets {
     private _translationSets: { [locale: string]: TranslationSet } = {};
 
-    private _settings: LinguaSettings | null = null;
+    private _settings: LinguaSettings = new LinguaSettings();
 
     public uris: { [locale: string]: Uri } = {};
 
@@ -20,12 +20,12 @@ export class TranslationSets {
      * Return either the default translation set if defined, otherwise try to return the
      * first one.
      */
-    public get default(): TranslationSet | null {
+    public get default(): TranslationSet {
         if (!this._settings || Object.keys(this._translationSets).length === 0) {
-            return null;
+            return new TranslationSet();
         }
-        const defaultLocale = this._settings.defaultLang
-            ? this._settings.defaultLang
+        const defaultLocale = this._settings.defaultLanguage
+            ? this._settings.defaultLanguage
             : Object.keys(this._translationSets)[0];
         return this._translationSets[defaultLocale];
     }


### PR DESCRIPTION
A user can now select a plain text and hit 'Convert text to translation' in the context menu.
After entering a translation path, the translation will be added.