### PR TITLE
feat: Autocomplete for translation identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "lingua-vscode",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "email": "chr33z@gmail.com"
     },
     "publisher": "chr33z",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "engines": {
         "vscode": "^1.39.0"
     },

--- a/src/auto-complete.ts
+++ b/src/auto-complete.ts
@@ -1,0 +1,53 @@
+import {
+    CompletionItemProvider,
+    TextDocument,
+    Position,
+    CancellationToken,
+    CompletionContext,
+    ProviderResult,
+    CompletionItem,
+    CompletionList,
+    MarkdownString,
+    Selection,
+    Range,
+} from 'vscode';
+import { TranslationSets } from './translation/translation-sets';
+
+export default class AutoCompleteProvider implements CompletionItemProvider {
+    constructor(private _translationSets: TranslationSets) {}
+
+    provideCompletionItems(
+        document: TextDocument,
+        position: Position,
+        token: CancellationToken,
+        context: CompletionContext
+    ): ProviderResult<CompletionItem[] | CompletionList> {
+        if (!this._translationSets) {
+            return;
+        }
+
+        if (!this.canAutoComplete(document, position)) {
+            return;
+        }
+
+        let translationCompletes: CompletionItem[] = [];
+        this._translationSets.default.keys.forEach(key => {
+            const item = new CompletionItem(key);
+            const translation = this._translationSets.default.hasTranslation(key) || undefined;
+            item.documentation = new MarkdownString(translation);
+            translationCompletes.push(item);
+        });
+
+        return translationCompletes;
+    }
+
+    /**
+     *
+     * @param document For now a simple validation if the substring 'translate' is contained in the line
+     * @param position
+     */
+    private canAutoComplete(document: TextDocument, position: Position): boolean {
+        const line = document.getText(new Range(position.line, 0, position.line + 1, 0));
+        return line.includes('translate');
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { updateTranslationDecorations } from './decoration';
 import { readSettings, writeSettings } from './lingua-settings';
 import AnalysisReportProvider from './analysis/analysis-report-provider';
 import { posix } from 'path';
+import AutoCompleteProvider from './auto-complete';
 
 let settings: LinguaSettings;
 let translationSets: TranslationSets;
@@ -31,6 +32,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
     settings = await readSettings();
     translationSets = new TranslationSets();
+
+    /* Register completion item provider for translations identifiers */
+    let completionProvider = languages.registerCompletionItemProvider(
+        'html',
+        new AutoCompleteProvider(translationSets)
+    );
+    context.subscriptions.push(completionProvider);
 
     /* Register document provider for translation analysis */
     const provider = new AnalysisReportProvider(settings, translationSets);


### PR DESCRIPTION
A user can now place its cursor in an 'html' file and when typing an autocomplete list of translation identifiers is shown. The autocomplete list only works when the same line contains a "translate" keyword.

The restriction is exhaustive because I don't want to narrow the user too much when using the autocomplete. The feature might be missunderstood when it was only working in special edge cases.