### PR TITLE
Fix/config show inline translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -746,7 +746,8 @@
         "camelcase": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
         },
         "chai": {
             "version": "4.2.0",
@@ -1083,7 +1084,8 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
@@ -5003,6 +5005,7 @@
             "version": "13.1.2",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
             "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+            "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"

--- a/src/configuration-settings.ts
+++ b/src/configuration-settings.ts
@@ -6,11 +6,11 @@ export class Configuration {
     }
 
     public static maxTranslationLength(defaultLength: number = 80): number {
-        return workspace.getConfiguration('lingua').get<number>('decoration.maxTranslationLength') || defaultLength;
+        return workspace.getConfiguration('lingua').get<number>('decoration.maxTranslationLength', defaultLength);
     }
 
     public static showInlineTranslation(defaultShow: boolean = true): boolean {
-        return workspace.getConfiguration('lingua').get<boolean>('decoration.showInlineTranslation') || defaultShow;
+        return workspace.getConfiguration('lingua').get<boolean>('decoration.showInlineTranslation', defaultShow);
     }
 
     public static defaultLanguage(): string | undefined {


### PR DESCRIPTION
The option "show inline translation" now actually works. Problem was a default settings that always overwrote the actual setting with 'true'