### PR TITLE
fix: maxLookupLength setting now works as expected

### DIFF
--- a/src/configuration-settings.ts
+++ b/src/configuration-settings.ts
@@ -6,7 +6,7 @@ export class Configuration {
     }
 
     public static maxTranslationLength(defaultLength: number = 80): number {
-        return workspace.getConfiguration('lingua').get<number>('decoration.maxTranslationLength', defaultLength);
+        return workspace.getConfiguration('lingua').get<number>('decoration.maxLookupLength', defaultLength);
     }
 
     public static showInlineTranslation(defaultShow: boolean = true): boolean {


### PR DESCRIPTION
The option "show inline translation" now actually works. Problem was a default settings that always overwrote the actual setting with 'true'