### PR TITLE
Added color themes to extension parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,46 @@
           "type": "boolean",
           "default": true,
           "description": "Sort keys in json files"
+        },
+        "lingua.inlineColor.Light": {
+          "type": "string",
+          "default": "#146462",
+          "description": "Color of inline translations in light mode"
+        },
+        "lingua.inlineColor.Dark": {
+          "type": "string",
+          "default": "#1a8582",
+          "description": "Color of inline translations in dark mode"
+        },
+        "lingua.inlineColor.HighContrast": {
+          "type": "string",
+          "default": "#146462",
+          "description": "Color of inline translations in light mode"
+        },
+        "lingua.inlineColor.HighContrastLight": {
+          "type": "string",
+          "default": "#1a8582",
+          "description": "Color of inline translations in dark mode"
+        },
+        "lingua.potentialIdentifierColor.Light": {
+          "type": "string",
+          "default": "#b7950b",
+          "description": "Color of a potential identifier in light mode"
+        },
+        "lingua.potentialIdentifierColor.Dark": {
+          "type": "string",
+          "default": "#b7950b",
+          "description": "Color of a potential identifier in dark mode"
+        },
+        "lingua.potentialIdentifierColor.HighContrast": {
+          "type": "string",
+          "default": "#b7950b",
+          "description": "Color of a potential identifier in light mode"
+        },
+        "lingua.potentialIdentifierColor.HighContrastLight": {
+          "type": "string",
+          "default": "#b7950b",
+          "description": "Color of a potential identifier in dark mode"
         }
       }
     }

--- a/src/configuration-settings.ts
+++ b/src/configuration-settings.ts
@@ -1,4 +1,4 @@
-import { workspace } from 'vscode';
+import { ColorThemeKind, workspace } from 'vscode';
 
 export class Configuration {
     public static useFlatTranslationKeys(): boolean {
@@ -43,5 +43,15 @@ export class Configuration {
 
     public static sortKeys(): boolean {
         return workspace.getConfiguration('lingua').get<boolean>('sortKeys', false);
+    }
+
+    public static getInlineColor(theme: ColorThemeKind): string {
+        const themeName = ColorThemeKind[theme];
+        return workspace.getConfiguration('lingua').get<string>(`inlineColor.${themeName}`, "#1a8582");
+    }
+
+    public static getPotentialIdentifierColor(theme: ColorThemeKind): string {
+        const themeName = ColorThemeKind[theme];
+        return workspace.getConfiguration('lingua').get<string>(`potentialIdentifierColor.${themeName}`, "#b7950b");
     }
 }

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -3,23 +3,7 @@ import { TranslationSet } from './translation/translation-set';
 import { posix } from 'path';
 import { Configuration } from './configuration-settings';
 
-const translationDecoration = window.createTextEditorDecorationType({
-    light: {
-        textDecoration: 'underline #146462',
-    },
-    dark: {
-        textDecoration: 'underline #1a8582',
-    },
-});
 
-const potentialIdentifierDecoration = window.createTextEditorDecorationType({
-    light: {
-        textDecoration: 'underline #b7950b wavy',
-    },
-    dark: {
-        textDecoration: 'underline #b7950b wavy',
-    },
-});
 
 /**
  * Scan editor content for possible translations paths and decorate the translation paths
@@ -65,15 +49,40 @@ export function updateTranslationDecorations(editor: TextEditor, translationSet:
             // Partial translation
             const shortPath = path.length > n ? path.substr(0, n - 1) + '...' : path;
             const decoration = getDecoration(false, startPos, endPos, 'Translations available: ' + shortPath + ' ...');
-            translationDecorations.push(decoration);
+            identifierDecorations.push(decoration);
         }
     }
 
-    editor.setDecorations(translationDecoration, translationDecorations);
-    editor.setDecorations(potentialIdentifierDecoration, identifierDecorations);
+    editor.setDecorations(createTranslationDecoration(), translationDecorations);
+    editor.setDecorations(createPotentialIdentifierDecoration(), identifierDecorations);
+}
+
+function createTranslationDecoration() {
+    const theme = window.activeColorTheme.kind;
+    return window.createTextEditorDecorationType({
+        light: {
+            textDecoration: `underline ${Configuration.getInlineColor(theme)}`,
+        },
+        dark: {
+            textDecoration: `underline ${Configuration.getInlineColor(theme)}`,
+        },
+    });
+}
+
+function createPotentialIdentifierDecoration() {
+    const theme = window.activeColorTheme.kind;
+    return window.createTextEditorDecorationType({
+        light: {
+            textDecoration: `underline ${Configuration.getPotentialIdentifierColor(theme)} wavy`,
+        },
+        dark: {
+            textDecoration: `underline ${Configuration.getPotentialIdentifierColor(theme)} wavy`,
+        },
+    });
 }
 
 function getDecoration(showInline: boolean, from: Position, to: Position, translation: string) {
+    const theme = window.activeColorTheme.kind;
     if (showInline) {
         return {
             range: new Range(from, to),
@@ -81,7 +90,7 @@ function getDecoration(showInline: boolean, from: Position, to: Position, transl
             renderOptions: {
                 after: {
                     contentText: ' • ' + translation,
-                    color: { id: 'lingua.lookupColor' },
+                    color: `${Configuration.getInlineColor(theme)}`,
                 },
             },
         };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,8 +70,6 @@ export async function activate(context: vscode.ExtensionContext) {
         })
     );
 
-
-
     /* Create a translation for the selected translation identifier */
     context.subscriptions.push(
         vscode.commands.registerTextEditorCommand('lingua.createTranslation', async (editor: TextEditor) => {


### PR DESCRIPTION
Colors of inline translations can now be changed according to the color theme in the extension settings. There are new entries to define colors for Light, Dark. High Contrast Light and High Contrast Dark color themes